### PR TITLE
Change default time zone to Etc/UTC

### DIFF
--- a/templates/production.py.erb
+++ b/templates/production.py.erb
@@ -19,6 +19,8 @@ from .base import *  # noqa
 # https://docs.djangoproject.com/en/2.2/ref/settings/#core-settings
 #
 
+TIME_ZONE = 'Etc/UTC'
+
 # Security
 #
 # You'll need to replace this to a random string. The following python code can


### PR DESCRIPTION
The default timezone from base.py is Australia/Canberra which is usually less than useful.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>