### PR TITLE
getmail.service: Use RestartSec to throttle restarts

### DIFF
--- a/templates/getmail.service.erb
+++ b/templates/getmail.service.erb
@@ -1,10 +1,12 @@
 [Unit]
 Description=Getmail for <%= @imap_username %>
+StartLimitIntervalSec=0
 
 [Service]
 User=getmail
 ExecStart=/usr/bin/getmail --getmaildir=/etc/getmail/<%= @imap_username %> --idle INBOX
 Restart=always
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When the server is refusing the connection, getmail might restart pretty quickly, leading to systemd
stopping the restart tries.

Instead make sure we do not restart too quickly
(getmail is not really a time-critical service)
but make sure we will retry indefinitely.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>